### PR TITLE
Bump the aws-iam-provisio` release's chart version to 0.2.1 to handle…

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,4 +1,26 @@
-# Deps Release Notes
+# Cluster Deps Release Notes
+
+## Release v0.3.2
+
+## What's new
+
+## Bug fixes
+- Bump the `aws-iam-provision` release's chart version to `0.2.1` to handle null items correctly in the template ranges.
+
+## Additional information
+
+### Mandatory updates for `project.yaml`
+
+### List of updated releases
+```yaml
+  - name: aws-iam-provision
+    chart: core-charts/aws-iam-provision
+    version: 0.2.1
+```
+
+### List of added releases
+
+---
 
 ## Release v0.3.1
 

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -160,7 +160,7 @@ releases:
   - name: aws-iam-provision
     namespace: capa-system
     chart: "{{`{{ .Release.Labels.repo }}`}}/aws-iam-provision"
-    version: 0.2.0
+    version: 0.2.1
     labels:
       cluster: aws
     installed: {{ eq (env "CAPI_CLUSTER" | default "false") "true" }}


### PR DESCRIPTION
… null items correctly in the template ranges.