### PR TITLE
Bumped the `gcp-cluster` release's chart version to `0.2.2` to disabl…

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,8 +1,30 @@
 # Cluster Deps Release Notes
 
+## Release v0.6.0
+
+## What's new
+
+- Bumped the `gcp-cluster` release's chart version to `0.2.2` to disable `loggingService` and `monitoringService` by
+  default.
+- Changed the `clusterctl-config`'s `gcp` provider to use the new `edenlabllc/cluster-api-provider-gcp` OSS GitHub fork
+  of version `v1.8.2`.
+
+## Bug fixes
+
+## Additional information
+
+### Mandatory updates for `project.yaml`
+
+### List of updated releases
+
+### List of added releases
+
+---
+
 ## Release v0.5.0
 
 ## What's new
+
 - Bumped `helmfile.hooks.infra` version to `v1.31.1`.
 
 ## Bug fixes
@@ -10,6 +32,7 @@
 ## Additional information
 
 ### Mandatory updates for `project.yaml`
+
 ```yaml
 inventory:
   hooks:
@@ -26,6 +49,7 @@ inventory:
 ## Release v0.4.0
 
 ## What's new
+
 - Added support for installing config extensions in `CAPI` management clusters.
 - Added custom identity name support for multiple cloud providers.
 - Added conditional `k3d-cluster` installation based on `RMK_COMMAND_CATEGORY` and `K3D_CLUSTER` environment variables.
@@ -48,6 +72,7 @@ inventory:
 ## Release v0.3.3
 
 ## What's new
+
 - Bumped `helmfile.hooks.infra` version to `v1.30.1`.
 - Project update has been enabled for tenant `deps.bootstrap.infra`.
 
@@ -56,6 +81,7 @@ inventory:
 ## Additional information
 
 ### Mandatory updates for `project.yaml`
+
 ```yaml
 inventory:
   hooks:
@@ -74,13 +100,15 @@ inventory:
 ## What's new
 
 ## Bug fixes
-- Bump the `aws-iam-provision` release's chart version to `0.2.1` to handle null items correctly in the template ranges.
+
+- Bumped the `aws-iam-provision` release's chart version to `0.2.1` to handle null items correctly in the template ranges.
 
 ## Additional information
 
 ### Mandatory updates for `project.yaml`
 
 ### List of updated releases
+
 ```yaml
   - name: aws-iam-provision
     chart: core-charts/aws-iam-provision
@@ -94,6 +122,7 @@ inventory:
 ## Release v0.3.1
 
 ## What's new
+
 - Bumped `helmfile.hooks.infra` version to `v1.30.0`.
 
 ## Bug fixes
@@ -101,6 +130,7 @@ inventory:
 ## Additional information
 
 ### Mandatory updates for `project.yaml`
+
 ```yaml
 inventory:
   hooks:
@@ -117,6 +147,7 @@ inventory:
 ## Release v0.3.0
 
 ## What's new
+
 - Added role and policy for `ebs-snapshot-provision-operator`.
 - Bumped `tenant-artifact` GitHub Action to `v2` for tenant repositories which use the new `v0.45.0` RMK version.
 - Bumped `kubectl` version to `v1.30.10` for proper support of Kubernetes `v1.30.X`.
@@ -130,6 +161,7 @@ inventory:
 ## Additional information
 
 ### Mandatory updates for `project.yaml`
+
 ```yaml
 inventory:
   hooks:
@@ -143,6 +175,7 @@ inventory:
 ```
 
 ### List of updated releases
+
 ```yaml
   - name: aws-iam-provision
     chart: core-charts/aws-iam-provision
@@ -165,6 +198,7 @@ inventory:
 ## Release v0.2.0
 
 ## What's new
+
 - Added example K3D cluster configuration values.
 - Updated `GCP GKE` control plane version to `v1.30.8`.
 - Changed the sequence of launching releases for `aws-iam-config`.
@@ -177,6 +211,7 @@ inventory:
 ### Mandatory updates for `project.yaml`
 
 ### List of updated releases
+
 ```yaml
   - name: aws-iam-config
     chart: core-charts/aws-iam-config
@@ -193,6 +228,7 @@ inventory:
 ## Release v0.1.0
 
 ## What's new
+
 - Prepared repository for OSS.
 - Added project structure files.
 
@@ -205,6 +241,7 @@ inventory:
 ### List of updated releases
 
 ### List of added releases
+
 ```yaml
   - name: capi-cluster
     chart: core-charts/k3d-cluster

--- a/etc/deps/develop/globals.yaml.gotmpl
+++ b/etc/deps/develop/globals.yaml.gotmpl
@@ -90,19 +90,6 @@ hooks:
       command: "{{`{{ .Release.Labels.bin }}`}}/common-postuninstall-hook.sh"
       args:
         - "{{`{{ .Release.Namespace }}`}}"
-  gcp-cluster:
-    # TODO: The hook is needed for resolving the issue with empty kubernetesTaints values for GKE machines pools.
-    #       This temporary solution may be deprecated in the subsequent releases.
-    #       https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1371
-    gcp-cluster-presync-hook:
-      events:
-        - presync
-      showlogs: true
-      command: "{{`{{ .Release.Labels.bin }}`}}/gcp-cluster-presync-hook.sh"
-      args:
-        - capg-system
-        - public.ecr.aws/edenlabllc/core.cluster-api-gcp-controller
-        - v1.8.1
     gcp-cluster-postsync-hook:
       events:
         - postsync

--- a/etc/deps/develop/values/clusterctl-config.yaml.gotmpl
+++ b/etc/deps/develop/values/clusterctl-config.yaml.gotmpl
@@ -31,7 +31,7 @@ providers:
     url: https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/v1.17.0/infrastructure-components.yaml
   - name: gcp
     type: InfrastructureProvider
-    url: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/v1.8.0/infrastructure-components.yaml
+    url: https://github.com/edenlabllc/cluster-api-provider-gcp/releases/v1.8.2/infrastructure-components.yaml
 
 variables: {}
 #  FOO: value

--- a/etc/deps/production/globals.yaml.gotmpl
+++ b/etc/deps/production/globals.yaml.gotmpl
@@ -91,18 +91,6 @@ hooks:
       args:
         - "{{`{{ .Release.Namespace }}`}}"
   gcp-cluster:
-    # TODO: The hook is needed for resolving the issue with empty kubernetesTaints values for GKE machines pools.
-    #       This temporary solution may be deprecated in the subsequent releases.
-    #       https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1371
-    gcp-cluster-presync-hook:
-      events:
-        - presync
-      showlogs: true
-      command: "{{`{{ .Release.Labels.bin }}`}}/gcp-cluster-presync-hook.sh"
-      args:
-        - capg-system
-        - public.ecr.aws/edenlabllc/core.cluster-api-gcp-controller
-        - v1.8.1
     gcp-cluster-postsync-hook:
       events:
         - postsync

--- a/etc/deps/production/values/clusterctl-config.yaml.gotmpl
+++ b/etc/deps/production/values/clusterctl-config.yaml.gotmpl
@@ -31,7 +31,7 @@ providers:
     url: https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/v1.17.0/infrastructure-components.yaml
   - name: gcp
     type: InfrastructureProvider
-    url: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/v1.8.0/infrastructure-components.yaml
+    url: https://github.com/edenlabllc/cluster-api-provider-gcp/releases/v1.8.2/infrastructure-components.yaml
 
 variables: {}
 #  FOO: value

--- a/etc/deps/staging/globals.yaml.gotmpl
+++ b/etc/deps/staging/globals.yaml.gotmpl
@@ -91,18 +91,6 @@ hooks:
       args:
         - "{{`{{ .Release.Namespace }}`}}"
   gcp-cluster:
-    # TODO: The hook is needed for resolving the issue with empty kubernetesTaints values for GKE machines pools.
-    #       This temporary solution may be deprecated in the subsequent releases.
-    #       https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1371
-    gcp-cluster-presync-hook:
-      events:
-        - presync
-      showlogs: true
-      command: "{{`{{ .Release.Labels.bin }}`}}/gcp-cluster-presync-hook.sh"
-      args:
-        - capg-system
-        - public.ecr.aws/edenlabllc/core.cluster-api-gcp-controller
-        - v1.8.1
     gcp-cluster-postsync-hook:
       events:
         - postsync

--- a/etc/deps/staging/values/clusterctl-config.yaml.gotmpl
+++ b/etc/deps/staging/values/clusterctl-config.yaml.gotmpl
@@ -31,7 +31,7 @@ providers:
     url: https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/v1.17.0/infrastructure-components.yaml
   - name: gcp
     type: InfrastructureProvider
-    url: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/v1.8.0/infrastructure-components.yaml
+    url: https://github.com/edenlabllc/cluster-api-provider-gcp/releases/v1.8.2/infrastructure-components.yaml
 
 variables: {}
 #  FOO: value

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -194,7 +194,7 @@ releases:
   - name: gcp-cluster
     namespace: capg-{{ env "NAME" }}
     chart: "{{`{{ .Release.Labels.repo }}`}}/gcp-cluster"
-    version: 0.2.1
+    version: 0.2.2
     labels:
       cluster: gcp
     installed: {{ eq (env "CAPI_CLUSTER" | default "false") "true" }}


### PR DESCRIPTION
…e `loggingService` and `monitoringService` by default. Changed the `clusterctl-config`'s `gcp` provider to use the new `edenlabllc/cluster-api-provider-gcp` OSS GitHub fork of version `v1.8.2`.