### PR TITLE
Bump `onprem-cluster` k3s version to `v1.34.4+k3s1` with `traefik` do…

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,7 +6,7 @@
 
 - Bumped `onprem` `InfrastructureProvider` version to `v0.2.0`.
 - Bumped `onprem-cluster` chart version to `v0.2.0`.
-- Bumped `onprem-cluster` k3s version to `v1.34.4+k3s1`.
+- Bumped `onprem-cluster` k3s version to `v1.34.4+k3s1` with `traefik` downgraded to `v2` for backward compatibility.
 
 ## Bug fixes
 

--- a/etc/deps/develop/values/onprem-cluster.yaml.gotmpl
+++ b/etc/deps/develop/values/onprem-cluster.yaml.gotmpl
@@ -8,6 +8,35 @@ templates:
   machineRemoteServerSpec: &machineRemoteServerSpec
     # providerID will automatically be set by edenlabllc/on-premise-configurator.operators.infra
     k3sAirGapEnabled: false
+    # K3S >= 1.32 bundles Traefik v3 which ships Gateway API CRDs
+    # (httproutes.gateway.networking.k8s.io, etc.). These CRDs conflict with
+    # Linkerd's own Gateway API CRDs causing Helm ownership errors during
+    # install/upgrade of either chart. Pinning Traefik to v2 avoids the
+    # Gateway API CRD conflict entirely, since Traefik v2 does not use them.
+    # NOTE: the bundled Helm chart is still v3-era; v2 image is compatible
+    # for basic IngressRoute / Ingress usage but Gateway API features are
+    # unavailable (which is the desired state to avoid the conflict).
+    k3sExtraManifests:
+      traefik-v2.yaml: |
+        ---
+        apiVersion: helm.cattle.io/v1
+        kind: HelmChart
+        metadata:
+          name: traefik-crd
+          namespace: kube-system
+        spec:
+          chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-27.0.201+up27.0.2.tgz
+        ---
+        apiVersion: helm.cattle.io/v1
+        kind: HelmChartConfig
+        metadata:
+          name: traefik
+          namespace: kube-system
+        spec:
+          chart: https://%{KUBERNETES_API}%/static/charts/traefik-27.0.201+up27.0.2.tgz
+          valuesContent: |-
+            image:
+              tag: "2.11.24"
     k3sRole: server
     sshUser: root
 

--- a/etc/deps/production/values/onprem-cluster.yaml.gotmpl
+++ b/etc/deps/production/values/onprem-cluster.yaml.gotmpl
@@ -8,6 +8,35 @@ templates:
   machineRemoteServerSpec: &machineRemoteServerSpec
     # providerID will automatically be set by edenlabllc/on-premise-configurator.operators.infra
     k3sAirGapEnabled: false
+    # K3S >= 1.32 bundles Traefik v3 which ships Gateway API CRDs
+    # (httproutes.gateway.networking.k8s.io, etc.). These CRDs conflict with
+    # Linkerd's own Gateway API CRDs causing Helm ownership errors during
+    # install/upgrade of either chart. Pinning Traefik to v2 avoids the
+    # Gateway API CRD conflict entirely, since Traefik v2 does not use them.
+    # NOTE: the bundled Helm chart is still v3-era; v2 image is compatible
+    # for basic IngressRoute / Ingress usage but Gateway API features are
+    # unavailable (which is the desired state to avoid the conflict).
+    k3sExtraManifests:
+      traefik-v2.yaml: |
+        ---
+        apiVersion: helm.cattle.io/v1
+        kind: HelmChart
+        metadata:
+          name: traefik-crd
+          namespace: kube-system
+        spec:
+          chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-27.0.201+up27.0.2.tgz
+        ---
+        apiVersion: helm.cattle.io/v1
+        kind: HelmChartConfig
+        metadata:
+          name: traefik
+          namespace: kube-system
+        spec:
+          chart: https://%{KUBERNETES_API}%/static/charts/traefik-27.0.201+up27.0.2.tgz
+          valuesContent: |-
+            image:
+              tag: "2.11.24"
     k3sRole: server
     sshUser: root
 

--- a/etc/deps/staging/values/onprem-cluster.yaml.gotmpl
+++ b/etc/deps/staging/values/onprem-cluster.yaml.gotmpl
@@ -8,6 +8,35 @@ templates:
   machineRemoteServerSpec: &machineRemoteServerSpec
     # providerID will automatically be set by edenlabllc/on-premise-configurator.operators.infra
     k3sAirGapEnabled: false
+    # K3S >= 1.32 bundles Traefik v3 which ships Gateway API CRDs
+    # (httproutes.gateway.networking.k8s.io, etc.). These CRDs conflict with
+    # Linkerd's own Gateway API CRDs causing Helm ownership errors during
+    # install/upgrade of either chart. Pinning Traefik to v2 avoids the
+    # Gateway API CRD conflict entirely, since Traefik v2 does not use them.
+    # NOTE: the bundled Helm chart is still v3-era; v2 image is compatible
+    # for basic IngressRoute / Ingress usage but Gateway API features are
+    # unavailable (which is the desired state to avoid the conflict).
+    k3sExtraManifests:
+      traefik-v2.yaml: |
+        ---
+        apiVersion: helm.cattle.io/v1
+        kind: HelmChart
+        metadata:
+          name: traefik-crd
+          namespace: kube-system
+        spec:
+          chart: https://%{KUBERNETES_API}%/static/charts/traefik-crd-27.0.201+up27.0.2.tgz
+        ---
+        apiVersion: helm.cattle.io/v1
+        kind: HelmChartConfig
+        metadata:
+          name: traefik
+          namespace: kube-system
+        spec:
+          chart: https://%{KUBERNETES_API}%/static/charts/traefik-27.0.201+up27.0.2.tgz
+          valuesContent: |-
+            image:
+              tag: "2.11.24"
     k3sRole: server
     sshUser: root
 


### PR DESCRIPTION
…wngraded to `v2` for backward compatibility.