### PR TITLE
#13 - bump aws-iam-provision-operator version to v0.3.1 to fix potent…

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,23 @@
 # Cluster Deps Release Notes
 
+## Release v2.1.2
+
+## What's new
+
+## Bug fixes
+
+- Bump `aws-iam-provision-operator` version to `v0.3.1` to fix potential stale `AWS` credentials usage in `IAM` client.
+
+## Additional information
+
+### Mandatory updates for `project.yaml`
+
+### List of updated releases
+
+### List of added releases
+
+---
+
 ## Release v2.1.1
 
 ## What's new

--- a/etc/deps/develop/values/aws-iam-provision-operator.yaml.gotmpl
+++ b/etc/deps/develop/values/aws-iam-provision-operator.yaml.gotmpl
@@ -382,7 +382,7 @@ replicaCount: 1
 
 image:
   repository: public.ecr.aws/edenlabllc/core.aws-iam-provisioner.operators.infra
-  tag: v0.3.0
+  tag: v0.3.1
 
 podAnnotations:
   linkerd.io/inject: {{ "disabled" | default .Values.configs.linkerd.inject }}

--- a/etc/deps/production/values/aws-iam-provision-operator.yaml.gotmpl
+++ b/etc/deps/production/values/aws-iam-provision-operator.yaml.gotmpl
@@ -382,7 +382,7 @@ replicaCount: 1
 
 image:
   repository: public.ecr.aws/edenlabllc/core.aws-iam-provisioner.operators.infra
-  tag: v0.3.0
+  tag: v0.3.1
 
 podAnnotations:
   linkerd.io/inject: {{ "disabled" | default .Values.configs.linkerd.inject }}

--- a/etc/deps/staging/values/aws-iam-provision-operator.yaml.gotmpl
+++ b/etc/deps/staging/values/aws-iam-provision-operator.yaml.gotmpl
@@ -382,7 +382,7 @@ replicaCount: 1
 
 image:
   repository: public.ecr.aws/edenlabllc/core.aws-iam-provisioner.operators.infra
-  tag: v0.3.0
+  tag: v0.3.1
 
 podAnnotations:
   linkerd.io/inject: {{ "disabled" | default .Values.configs.linkerd.inject }}


### PR DESCRIPTION
…ial stale AWS credentials usage in IAM client