### PR TITLE
Update release notes and configuration files to bump `onprem` `Infras…

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,7 +18,7 @@
 - Bumped `capi-cluster` / `k3d-cluster` chart version to `0.3.0` (`appVersion` `v1.36.2` → default image `rancher/k3s:v1.36.2-k3s1`).
 - Explicitly pinned `capi-cluster` and `k3d-cluster` image to `rancher/k3s:v1.36.2-k3s1` in values (same as chart default; keeps K8s version visible in this repo).
 - Bumped `onprem-cluster` chart version to `0.3.2` (default k3s `v1.36.2+k3s1`; sanitize `app.kubernetes.io/version` `+` → `-`; `Cluster` / `Machine` → `cluster.x-k8s.io/v1beta2` with `apiGroup` refs).
-- Bumped `onprem` `InfrastructureProvider` version to `v0.3.0` (`metadata.yaml` contract `v1beta2`, `status.initialization.*`, CRD `cluster.x-k8s.io/v1beta2` label).
+- Bumped `onprem` `InfrastructureProvider` version to `v0.3.1` (`metadata.yaml` contract `v1beta2`, `status.initialization.*`, CRD `cluster.x-k8s.io/v1beta2` label, `K3SCluster` readiness reconcile fix without `json_query`/`jmespath` dependency).
 - Bumped `app` chart version (`appChartVersion`) to `2.2.0` for `aws-iam-provision-operator`.
 
 ## Bug fixes
@@ -26,7 +26,7 @@
 - Pinned `helm` to `3.21.2` in `project.yaml` to keep RMK Helm plugin compatibility (including `helm-diff`) in this release flow.
 - Increased `capi-cluster` and `k3d-cluster` k3d wait timeouts to `300s` in develop/staging/production to reduce startup failures on slower image pulls.
 - Fixed `postsync-wait-aws-cluster-ready.sh` for CAPI `v1beta2` by mapping removed `v1beta1` status booleans to `status.initialization` fields while keeping the original readiness checks.
-- Fixed `postsync-wait-onprem-cluster-ready.sh` for CAPI `v1beta2` (`status.initialization.*` only). Requires onprem provider `v0.3.0+`.
+- Fixed `postsync-wait-onprem-cluster-ready.sh` for CAPI `v1beta2` (`status.initialization.*` only). Requires onprem provider `v0.3.1+`.
 
 ## Additional information
 

--- a/etc/deps/develop/values/clusterctl-config.yaml.gotmpl
+++ b/etc/deps/develop/values/clusterctl-config.yaml.gotmpl
@@ -46,7 +46,7 @@ providers:
     url: https://github.com/edenlabllc/cluster-api-provider-gcp/releases/v1.13.1/infrastructure-components.yaml
   - name: onprem
     type: InfrastructureProvider
-    url: https://github.com/edenlabllc/on-premise-configurator.operators.infra/releases/v0.3.0/infrastructure-components.yaml
+    url: https://github.com/edenlabllc/on-premise-configurator.operators.infra/releases/v0.3.1/infrastructure-components.yaml
 
 variables: {}
 #  FOO: value

--- a/etc/deps/production/values/clusterctl-config.yaml.gotmpl
+++ b/etc/deps/production/values/clusterctl-config.yaml.gotmpl
@@ -46,7 +46,7 @@ providers:
     url: https://github.com/edenlabllc/cluster-api-provider-gcp/releases/v1.13.1/infrastructure-components.yaml
   - name: onprem
     type: InfrastructureProvider
-    url: https://github.com/edenlabllc/on-premise-configurator.operators.infra/releases/v0.3.0/infrastructure-components.yaml
+    url: https://github.com/edenlabllc/on-premise-configurator.operators.infra/releases/v0.3.1/infrastructure-components.yaml
 
 variables: {}
 #  FOO: value

--- a/etc/deps/staging/values/clusterctl-config.yaml.gotmpl
+++ b/etc/deps/staging/values/clusterctl-config.yaml.gotmpl
@@ -46,7 +46,7 @@ providers:
     url: https://github.com/edenlabllc/cluster-api-provider-gcp/releases/v1.13.1/infrastructure-components.yaml
   - name: onprem
     type: InfrastructureProvider
-    url: https://github.com/edenlabllc/on-premise-configurator.operators.infra/releases/v0.3.0/infrastructure-components.yaml
+    url: https://github.com/edenlabllc/on-premise-configurator.operators.infra/releases/v0.3.1/infrastructure-components.yaml
 
 variables: {}
 #  FOO: value


### PR DESCRIPTION
…tructureProvider` version to `v0.3.1`, including a readiness reconcile fix. Adjust URLs in clusterctl-config for all environments to point to the new release version.